### PR TITLE
Various improvements

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,21 @@
 ---------------------------------------------------------------------------------------------------
+Version: 1.1.0
+Date: 2020/12/14
+  Changes:
+    - tweaked locomotive recipe: Reduced recipe from 4 steam engines to 1. Compensated by adding 10 iron gears.
+---------------------------------------------------------------------------------------------------
+Version: 1.0.1
+Date: 2020/12/12
+  Changes:
+    - re-added optional dependency to barrels-of-steam after their update to 1.1.
+    - steam barrels can be used in steam locomotives as an alternative to fluid steam. This is useful - for instance - to bring a locomotive to a refueling station when it has run out of fuel.
+---------------------------------------------------------------------------------------------------
+Version: 1.0.0
+Date: 2020/12/09
+  Changes:
+    - compatibility update for fluidTrains 1.0.0 and factorio 1.1
+    - removed optional dependency to barrels-of-steam. Not yet updated for 1.1.
+---------------------------------------------------------------------------------------------------
 Version: 0.18.9
 Date: 2020/05/04
   Change:

--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -2,15 +2,22 @@ local tankApi = require "__fluidTrains__/api/data"
 
 tankApi.generateTank(20000)
 
-local function patchBarrel(barrel, energy)
+local function patchBarrel(barrel, energy, hot)
 	if barrel then
 		if not barrel.fuel_category then
 			barrel.fuel_category = "SteamTrains-steam"
 			barrel.fuel_value = energy
 			barrel.burnt_result = "empty-barrel"
+			if hot then
+				barrel.fuel_acceleration_multiplier = settings.startup["steamTrains_hot_steam_accel_mult"].value
+				barrel.fuel_top_speed_multiplier = settings.startup["steamTrains_hot_steam_topspeed_mult"].value
+			else
+				barrel.fuel_acceleration_multiplier = settings.startup["steamTrains_steam_accel_mult"].value
+				barrel.fuel_top_speed_multiplier = settings.startup["steamTrains_steam_topspeed_mult"].value
+			end
 		end
 	end
 end
 
-patchBarrel(data.raw["item"]["steam-barrel-165"], "1500kJ")
-patchBarrel(data.raw["item"]["steam-barrel-500"], "4850kJ")
+patchBarrel(data.raw["item"]["steam-barrel-165"], "1500kJ", false)
+patchBarrel(data.raw["item"]["steam-barrel-500"], "4850kJ", true)

--- a/info.json
+++ b/info.json
@@ -7,5 +7,5 @@
 	"homepage": "",
 	"description": "",
 	"factorio_version": "1.1",
-	"dependencies": ["base >= 1.1.5", "fluidTrains >= 1.0.0", "? barrels-of-steam >= 18.0.6" ]
+	"dependencies": ["base >= 1.1.5", "fluidTrains >= 1.0.0", "? barrels-of-steam >= 18.0.6", "? trainConstructionSite >= 0.2.19" ]
 }

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
 	"name": "steamTrains",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"title": "Steam Trains",
 	"author": "ksmonkey123",
 	"contact": "",

--- a/info.json
+++ b/info.json
@@ -1,11 +1,11 @@
 {
 	"name": "steamTrains",
-	"version": "0.18.9",
+	"version": "1.1.0",
 	"title": "Steam Trains",
 	"author": "ksmonkey123",
 	"contact": "",
 	"homepage": "",
 	"description": "",
-	"factorio_version": "0.18",
-	"dependencies": ["base >= 0.18.22", "fluidTrains >= 0.18.5", "? barrels-of-steam >= 18.0.5" ]
+	"factorio_version": "1.1",
+	"dependencies": ["base >= 1.1.5", "fluidTrains >= 1.0.0", "? barrels-of-steam >= 18.0.6" ]
 }

--- a/locale/en/locale_en.cfg
+++ b/locale/en/locale_en.cfg
@@ -17,3 +17,8 @@ SteamTrains-steam=Steam
 [fluid-name]
 SteamTrains-mixedSteam=Mixed steam
 SteamTrains-hotSteam=Superheated steam
+
+[mod-setting-name]
+steamTrains_enable_legacy=Enable legacy steam locomotive
+[mod-setting-description]
+steamTrains_enable_legacy=The legacy steam locomotive burns regular fuel but looks like a steam locomotive. It exists only for compatibility purposes and can't be built.

--- a/locale/en/locale_en.cfg
+++ b/locale/en/locale_en.cfg
@@ -20,5 +20,12 @@ SteamTrains-hotSteam=Superheated steam
 
 [mod-setting-name]
 steamTrains_enable_legacy=Enable legacy steam locomotive
+steamTrains_steam_accel_mult=Steam acceleration multiplier
+steamTrains_steam_topspeed_mult=Steam top speed multiplier
+steamTrains_mixed_steam_accel_mult=Mixed steam acceleration multiplier
+steamTrains_mixed_steam_topspeed_mult=Mixed steam top speed multiplier
+steamTrains_hot_steam_accel_mult=Hot steam acceleration multiplier
+steamTrains_hot_steam_topspeed_mult=Hot steam top speed multiplier
+
 [mod-setting-description]
 steamTrains_enable_legacy=The legacy steam locomotive burns regular fuel but looks like a steam locomotive. It exists only for compatibility purposes and can't be built.

--- a/prototypes/entities.lua
+++ b/prototypes/entities.lua
@@ -16,3 +16,8 @@ if settings.startup["steamTrains_enable_legacy"].value then
   data:extend({steam_loco})
 end
 
+
+if mods["trainConstructionSite"] and mods["barrels-of-steam"] then
+  require("__trainConstructionSite__/modding-interface")
+  trainConstructionSite.remote.addCustomFuelTrain("locomotive", "SteamTrains-locomotive", "steam-barrel-165")
+end

--- a/prototypes/entities.lua
+++ b/prototypes/entities.lua
@@ -6,11 +6,13 @@ fluid_locomotive.burner.fuel_category = "SteamTrains-steam"
 fluid_locomotive.burner.fuel_inventory_size = 1
 fluid_locomotive.burner.burnt_inventory_size = 1
 fluid_locomotive.color = { r = 0.2, g = 0.7, b = 1, a = 0.5 }
+data:extend({fluid_locomotive})
 
-local steam_loco = util.table.deepcopy(data.raw["locomotive"]["locomotive"])
-steam_loco.name = "steam-locomotive"
-steam_loco.minable.result = "SteamTrains-locomotive"
-steam_loco.color = { r = 0.2, g = 0.7, b = 1, a = 0.5 }
+if settings.startup["steamTrains_enable_legacy"].value then
+  local steam_loco = util.table.deepcopy(data.raw["locomotive"]["locomotive"])
+  steam_loco.name = "steam-locomotive"
+  steam_loco.minable.result = "SteamTrains-locomotive"
+  steam_loco.color = { r = 0.2, g = 0.7, b = 1, a = 0.5 }
+  data:extend({steam_loco})
+end
 
--- Add new locomotive to the game
-data:extend({steam_loco, fluid_locomotive})

--- a/prototypes/items.lua
+++ b/prototypes/items.lua
@@ -9,21 +9,23 @@ local fluid_locomotive_item = {
     place_result = "SteamTrains-locomotive",
     stack_size = 5
 }
+data:extend({fluid_locomotive_item})
 
-local old_locomotive = {
-    type = "item-with-entity-data",
-    name = "steam-locomotive",
-    icon = "__steamTrains__/graphics/icons/steam-locomotive.png",
-    icon_size = 64,
-	icon_mipmaps = 4,
-    subgroup = "transport",
-    order = "a[train-system]-fz[diesel-locomotive]",
-    place_result = "steam-locomotive",
-    stack_size = 5,
-	flags = { "hidden" }
-}
-
-data:extend({fluid_locomotive_item, old_locomotive})
+if settings.startup["steamTrains_enable_legacy"].value then
+    local old_locomotive = {
+        type = "item-with-entity-data",
+        name = "steam-locomotive",
+        icon = "__steamTrains__/graphics/icons/steam-locomotive.png",
+        icon_size = 64,
+        icon_mipmaps = 4,
+        subgroup = "transport",
+        order = "a[train-system]-fz[diesel-locomotive]",
+        place_result = "steam-locomotive",
+        stack_size = 5,
+        flags = { "hidden" }
+    }
+    data:extend({old_locomotive})
+end
 
 local fluid_steam = data.raw["fluid"]["steam"]
 

--- a/prototypes/items.lua
+++ b/prototypes/items.lua
@@ -41,24 +41,24 @@ local steam_proxy = {
 	name = "SteamTrains-steamProxy",
 	localised_name = {"", {"fluid-name.steam"}},
 	fuel_value = "1500kJ",
-	fuel_acceleration_multiplier = 1.2,
-	fuel_top_speed_multiplier = 1.05
+	fuel_acceleration_multiplier = settings.startup["steamTrains_steam_accel_mult"].value,
+	fuel_top_speed_multiplier = settings.startup["steamTrains_steam_topspeed_mult"].value
 }
 
 local mixed_steam_proxy = table.deepcopy(steam_proxy)
 mixed_steam_proxy.name = "SteamTrains-mixedSteamProxy"
 mixed_steam_proxy.localised_name = {"", {"fluid-name.SteamTrains-mixedSteam"}}
 mixed_steam_proxy.fuel_value = "3MJ"
-mixed_steam_proxy.fuel_acceleration_multiplier = 1.4
-mixed_steam_proxy.fuel_top_speed_multiplier = 1.05
+mixed_steam_proxy.fuel_acceleration_multiplier = settings.startup["steamTrains_mixed_steam_accel_mult"].value
+mixed_steam_proxy.fuel_top_speed_multiplier = settings.startup["steamTrains_mixed_steam_topspeed_mult"].value
 mixed_steam_proxy.flags = {"hidden","hide-from-fuel-tooltip"}
 
 local hot_steam_proxy = table.deepcopy(steam_proxy)
 hot_steam_proxy.name = "SteamTrains-hotSteamProxy"
 hot_steam_proxy.localised_name = {"", {"fluid-name.SteamTrains-hotSteam"}}
 hot_steam_proxy.fuel_value = "4850kJ"
-hot_steam_proxy.fuel_acceleration_multiplier = 1.5
-hot_steam_proxy.fuel_top_speed_multiplier = 1.1
+hot_steam_proxy.fuel_acceleration_multiplier = settings.startup["steamTrains_hot_steam_accel_mult"].value
+hot_steam_proxy.fuel_top_speed_multiplier = settings.startup["steamTrains_hot_steam_topspeed_mult"].value
 hot_steam_proxy.flags = {"hidden","hide-from-fuel-tooltip"}
 
 data:extend({steam_proxy, mixed_steam_proxy, hot_steam_proxy})

--- a/prototypes/recipes.lua
+++ b/prototypes/recipes.lua
@@ -6,10 +6,10 @@ local locoRecipe = {
     ingredients =
     {
       {"steam-engine", 1},
-	  {"storage-tank", 1},
+	    {"storage-tank", 1},
       {"electronic-circuit", 10},
       {"steel-plate", 30},
-	  {"iron-gear-wheel", 10}, 
+	    {"iron-gear-wheel", 10},
     },
     result = "SteamTrains-locomotive"
 }

--- a/prototypes/recipes.lua
+++ b/prototypes/recipes.lua
@@ -5,10 +5,11 @@ local locoRecipe = {
     enabled = false,
     ingredients =
     {
-      {"steam-engine", 4},
+      {"steam-engine", 1},
 	  {"storage-tank", 1},
       {"electronic-circuit", 10},
-      {"steel-plate", 30}
+      {"steel-plate", 30},
+	  {"iron-gear-wheel", 10}, 
     },
     result = "SteamTrains-locomotive"
 }

--- a/prototypes/technologies.lua
+++ b/prototypes/technologies.lua
@@ -5,19 +5,19 @@ data:extend({
     icon = "__steamTrains__/graphics/technology/steam-locomotive.png",
     icon_size = 128,
     prerequisites = {"railway", "fluid-handling"},
-    effects = {},
-      unit =
+	effects = {},
+    unit =
+    {
+      ingredients =
       {
-        ingredients =
-        {
-          {"automation-science-pack", 1},
-          {"logistic-science-pack", 1},
-        },
-        time = 30,
-        count = 100
+        {"automation-science-pack", 1},
+        {"logistic-science-pack", 1},
       },
-      order = "c-g-a-b",
-    }
+      time = 30,
+      count = 100
+    },
+    order = "c-g-a-b",
+  }
 })
 
 table.insert(data.raw.technology["steam-locomotives"].effects, {type = "unlock-recipe", recipe = "SteamTrains-locomotive"})

--- a/prototypes/technologies.lua
+++ b/prototypes/technologies.lua
@@ -5,19 +5,19 @@ data:extend({
     icon = "__steamTrains__/graphics/technology/steam-locomotive.png",
     icon_size = 128,
     prerequisites = {"railway", "fluid-handling"},
-	effects = {},
-    unit =
-    {
-      ingredients =
+    effects = {},
+      unit =
       {
-        {"automation-science-pack", 1},
-        {"logistic-science-pack", 1},
+        ingredients =
+        {
+          {"automation-science-pack", 1},
+          {"logistic-science-pack", 1},
+        },
+        time = 30,
+        count = 100
       },
-      time = 30,
-      count = 100
-    },
-    order = "c-g-a-b",
-  }
+      order = "c-g-a-b",
+    }
 })
 
 table.insert(data.raw.technology["steam-locomotives"].effects, {type = "unlock-recipe", recipe = "SteamTrains-locomotive"})

--- a/settings.lua
+++ b/settings.lua
@@ -1,0 +1,8 @@
+data:extend({
+	{
+		type = "bool-setting",
+		name = "steamTrains_enable_legacy",
+		setting_type = "startup",
+		default_value = false
+	}
+})

--- a/settings.lua
+++ b/settings.lua
@@ -1,8 +1,57 @@
 data:extend({
-	{
-		type = "bool-setting",
-		name = "steamTrains_enable_legacy",
-		setting_type = "startup",
-		default_value = false
-	}
+  {
+    type = "bool-setting",
+    name = "steamTrains_enable_legacy",
+    order = "A",
+    setting_type = "startup",
+    default_value = false
+  },
+  {
+    type = "double-setting",
+    name = "steamTrains_steam_accel_mult",
+    order = "BA1",
+    setting_type = "startup",
+    default_value = 1.2,
+    minimum_value = 0,
+  },
+  {
+    type = "double-setting",
+    name = "steamTrains_steam_topspeed_mult",
+    order = "BA2",
+    setting_type = "startup",
+    default_value = 1.05,
+    minimum_value = 0,
+  },
+  {
+    type = "double-setting",
+    name = "steamTrains_mixed_steam_accel_mult",
+    order = "BB1",
+    setting_type = "startup",
+    default_value = 1.4,
+    minimum_value = 0,
+  },
+  {
+    type = "double-setting",
+    name = "steamTrains_mixed_steam_topspeed_mult",
+    order = "BB2",
+    setting_type = "startup",
+    default_value = 1.05,
+    minimum_value = 0,
+  },
+  {
+    type = "double-setting",
+    name = "steamTrains_hot_steam_accel_mult",
+    order = "BC1",
+    setting_type = "startup",
+    default_value = 1.5,
+    minimum_value = 0,
+  },
+  {
+    type = "double-setting",
+    order = "BC2",
+    name = "steamTrains_hot_steam_topspeed_mult",
+    setting_type = "startup",
+    default_value = 1.1,
+    minimum_value = 0,
+  },
 })


### PR DESCRIPTION
This PR mostly aims to add support for the *trainConstructionSite* mod. In lieu of implementing full fluid support there, I simply fall back to the *barrels-of-steam* mod in order to define a non-fluid fuel to be inserted by the train builder. The config option to disable the legacy locomotive is also needed because the recipe causes problems (even though it is hidden).